### PR TITLE
replace LazyLoad to LazyData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,5 +15,5 @@ Description: Implements various mainstream and specialised changepoint methods f
 Depends: R(>= 3.2), methods, stats, zoo(>= 0.9-1)
 Suggests: testthat
 License: GPL
-LazyLoad: yes
+LazyData: true
 Packaged: 2018-06-02 12:36:29 UTC; killick


### PR DESCRIPTION
`LazyLoad` is ignored since R 2.14.0.
https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file
> The ‘LazyData’ logical field controls whether the R datasets use lazy-loading. A ‘LazyLoad’ field was used in versions prior to 2.14.0, but now is ignored.