### PR TITLE
Proposed move to gh-actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,6 @@ jobs:
 
       # Only really need test coverage on one item in matrix.
       - name: Test coverage
-        if: matrix.config.os == 'ubuntu-latest' && matrix.config.r == '3.6'
+        if: matrix.config.os == 'ubuntu-16.04' && matrix.config.r == '3.6'
         run: |
           Rscript -e 'covr::codecov()'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,82 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: '3.6'}
+          - {os: macOS-latest, r: '3.6'}
+          - {os: macOS-latest, r: 'devel'} # Currently devel only available for macOS
+          - {os: macOS-latest, r: 'release'} # Currently release only available for macOS
+          - {os: macOS-latest, r: 'oldrel'} # Currently oldrel only available for macOS
+          - {os: ubuntu-16.04, r: '3.2', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.3', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          # Using R Studio package manager (RSPM) to cut install time.
+    env:
+      _R_CHECK_FORCE_SUGGESTS_: False
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+
+    steps:
+      # Checkout repository
+      - uses: actions/checkout@v2
+
+      # Setup and configure R
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      # Query package dependencies
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      # Linux only dependencies
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        env:
+          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+        run: |
+          Rscript -e "remotes::install_github('r-hub/sysreqs')"
+          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
+          sudo -s eval "$sysreqs"
+
+      # Install package dependencies and test suit
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      # Run Checks
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+
+      # Only really need test coverage on one item in matrix.
+      - name: Test coverage
+        if: matrix.config.os == 'ubuntu-latest' && matrix.config.r == '3.6'
+        run: |
+          Rscript -e 'covr::codecov()'


### PR DESCRIPTION
Added the necessary files for CI using gh-actions. This reduces the number of tools needed and provides native support for testing on non-Linux systems.

Current limitations are that devel, release and oldrel are only available as macOS binaries. This should be changed soon hopefully - it relies on RStudio who provide the TravisCI binaries or devel, release, and oldrel to produce ones for gh-actions (which they have a feature request in for at the minute)

Currently devel and release are failing checks but this is the same in Travis.

I have not deleted the .travis.yml as this can run in parallel (for the time being)