### PR TITLE
error on design(...,p<1)

### DIFF
--- a/R/design.R
+++ b/R/design.R
@@ -1,5 +1,8 @@
 #This function generates a user an (n-1)x(p+2) design matrix for their data and own choice of AR(p) model. This can be used directly with cpt.reg() but is unnecessary for cpt.ar() as it will be generated internally. 
 design <- function(data,p=1){
+    if (p<1){
+        stop("p must be >0")
+    }
     if(p>0.2*length(data)){
         warning("Due to the order of this model, there is a high risk of overfitting the data")
     }


### PR DESCRIPTION
This came up as part of going through package for the [rOpenSci Statistical Software Review](https://github.com/ropenscilabs/statistical-software-peer-review) project, in particular through applying the [`autotest` package](https://github.com/mpadge/autotest), which throws all sorts of unexpected input at packages. I'm opening PRs/issues for any code that behaves dangerously (generally meaning it kills my R session).

In this case, without this line, any negative values for `p` are passed through to
https://github.com/rkillick/changepoint/blob/34856c63778dbbdee84289310a8154208acf49ed/R/design.R#L7
and the `rep(1,n-p)` line will still generate results. Submitting `p = -.Machine$integer.max` generates very nasty results.