### PR TITLE
CROPS Penalty value fix

### DIFF
--- a/R/class_input.R
+++ b/R/class_input.R
@@ -41,7 +41,7 @@ class_input <- function(data, cpttype, method, test.stat, penalty, pen.value, mi
     m = t(sapply(out[[2]], '[', 1:max(sapply(out[[2]], length))))
     
     cpts.full(ans) = m
-    pen.value.full(ans) = out[[1]][1,]
+    pen.value.full(ans) = out[[1]][4,]
     if(test.stat=="Gamma"){param.est(ans)$shape=shape}
   }
   

--- a/R/range_of_penalties.R
+++ b/R/range_of_penalties.R
@@ -118,7 +118,7 @@ range_of_penalties <- function(sumstat,cost = "mean.norm",PELT = T,min_pen=log(l
     
   }
   
-  return(list(cpt.out = rbind(beta_interval = beta.int,numberofchangepoints,penalised_cost = penal),changepoints = segmentations))
+  return(list(cpt.out = rbind(beta_interval = beta.int,numberofchangepoints,penalised_cost = penal,pen_values=test_penalties),changepoints = segmentations))
   #segmentations is output matrix
   #beta.int
 }


### PR DESCRIPTION
The slot pen.value.full was being filled with the beta intervals from
the range_of_penalties function. Have added a new row to the first list
entry of the object returned from range_of_penalties which contains the
test penalties which I think are the penalties that should be in the
pen.value.fix slot. Have altered the class input so that this is now the
case. To return to undo the fix simply alter the slot assignment in
class_input from out[[1]][4,] to out[[1]][1,].